### PR TITLE
Update posthog URL to posthog.element.io

### DIFF
--- a/vector-config/src/main/java/im/vector/app/config/Config.kt
+++ b/vector-config/src/main/java/im/vector/app/config/Config.kt
@@ -79,7 +79,7 @@ object Config {
      * Can be disabled by providing Analytics.Disabled
      */
     val RELEASE_ANALYTICS_CONFIG = Analytics.PostHog(
-            postHogHost = "https://posthog.hss.element.io",
+            postHogHost = "https://posthog.element.io",
             postHogApiKey = "phc_Jzsm6DTm6V2705zeU5dcNvQDlonOR68XvX2sh1sEOHO",
             policyLink = "https://element.io/cookie-policy",
     )


### PR DESCRIPTION
The posthog ingress is no longer posthog.hss.element.io, and, although it is running in parallel it will be removed in the future.